### PR TITLE
Reintroduce old TmpFileSegmentWriteOutMedium

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/writeout/LegacyFileWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/LegacyFileWriteOutBytes.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.writeout;
+
+import com.google.common.io.ByteStreams;
+import org.apache.druid.io.Channels;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.IOE;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+
+final class LegacyFileWriteOutBytes extends WriteOutBytes
+{
+  private final File file;
+  private final FileChannel ch;
+  private long writeOutBytes;
+
+  /** Purposely big-endian, for {@link #writeInt(int)} implementation */
+  private final ByteBuffer buffer = ByteBuffer.allocate(4096); // 4K page sized buffer
+
+  LegacyFileWriteOutBytes(File file, FileChannel ch)
+  {
+    this.file = file;
+    this.ch = ch;
+    this.writeOutBytes = 0L;
+  }
+
+  private void flushIfNeeded(int bytesNeeded) throws IOException
+  {
+    if (buffer.remaining() < bytesNeeded) {
+      flush();
+    }
+  }
+
+  @Override
+  public void flush() throws IOException
+  {
+    buffer.flip();
+    try {
+      Channels.writeFully(ch, buffer);
+    }
+    catch (IOException e) {
+      throw new IOE(e, "Failed to write to file: %s. Current size of file: %d", file.getAbsolutePath(), writeOutBytes);
+    }
+    buffer.clear();
+  }
+
+  @Override
+  public void write(int b) throws IOException
+  {
+    flushIfNeeded(1);
+    buffer.put((byte) b);
+    writeOutBytes++;
+  }
+
+  @Override
+  public void writeInt(int v) throws IOException
+  {
+    flushIfNeeded(Integer.BYTES);
+    buffer.putInt(v);
+    writeOutBytes += Integer.BYTES;
+  }
+
+  @Override
+  public int write(ByteBuffer src) throws IOException
+  {
+    int len = src.remaining();
+    flushIfNeeded(len);
+    while (src.remaining() > buffer.capacity()) {
+      int srcLimit = src.limit();
+      try {
+        src.limit(src.position() + buffer.capacity());
+        buffer.put(src);
+        writeOutBytes += buffer.capacity();
+        flush();
+      }
+      finally {
+        // IOException may occur in flush(), reset src limit to the original
+        src.limit(srcLimit);
+      }
+    }
+    int remaining = src.remaining();
+    buffer.put(src);
+    writeOutBytes += remaining;
+    return len;
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException
+  {
+    write(ByteBuffer.wrap(b, off, len));
+  }
+
+  @Override
+  public long size()
+  {
+    return writeOutBytes;
+  }
+
+  @Override
+  public void writeTo(WritableByteChannel channel) throws IOException
+  {
+    flush();
+    ch.position(0);
+    try {
+      ByteStreams.copy(ch, channel);
+    }
+    finally {
+      ch.position(ch.size());
+    }
+  }
+
+  @Override
+  public void readFully(long pos, ByteBuffer buffer) throws IOException
+  {
+    if (pos < 0 || pos > writeOutBytes) {
+      throw new IAE("pos %d out of range [%d, %d]", pos, 0, writeOutBytes);
+    }
+    flush();
+    ch.read(buffer, pos);
+    if (buffer.remaining() > 0) {
+      throw new BufferUnderflowException();
+    }
+  }
+
+  @Override
+  public InputStream asInputStream() throws IOException
+  {
+    flush();
+    return new FileInputStream(file);
+  }
+
+  @Override
+  public boolean isOpen()
+  {
+    return ch.isOpen();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/writeout/LegacyTmpFileSegmentWriteOutMedium.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/LegacyTmpFileSegmentWriteOutMedium.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.writeout;
+
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.io.Closer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+
+public final class LegacyTmpFileSegmentWriteOutMedium implements SegmentWriteOutMedium
+{
+  private final File dir;
+  private final Closer closer = Closer.create();
+
+  LegacyTmpFileSegmentWriteOutMedium(File outDir) throws IOException
+  {
+    File tmpOutputFilesDir = new File(outDir, "tmpOutputFiles");
+    FileUtils.mkdirp(tmpOutputFilesDir);
+    closer.register(() -> FileUtils.deleteDirectory(tmpOutputFilesDir));
+    this.dir = tmpOutputFilesDir;
+  }
+
+  @Override
+  public WriteOutBytes makeWriteOutBytes() throws IOException
+  {
+    File file = File.createTempFile("filePeon", null, dir);
+    FileChannel ch = FileChannel.open(
+        file.toPath(),
+        StandardOpenOption.READ,
+        StandardOpenOption.WRITE
+    );
+    closer.register(file::delete);
+    closer.register(ch);
+    return new LegacyFileWriteOutBytes(file, ch);
+  }
+
+  @Override
+  public SegmentWriteOutMedium makeChildWriteOutMedium() throws IOException
+  {
+    LegacyTmpFileSegmentWriteOutMedium tmpFileSegmentWriteOutMedium = new LegacyTmpFileSegmentWriteOutMedium(dir);
+    closer.register(tmpFileSegmentWriteOutMedium);
+    return tmpFileSegmentWriteOutMedium;
+  }
+
+  @Override
+  public Closer getCloser()
+  {
+    return closer;
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    closer.close();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/writeout/LegacyTmpFileSegmentWriteOutMediumFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/LegacyTmpFileSegmentWriteOutMediumFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.writeout;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.io.File;
+import java.io.IOException;
+
+public final class LegacyTmpFileSegmentWriteOutMediumFactory implements SegmentWriteOutMediumFactory
+{
+  private static final LegacyTmpFileSegmentWriteOutMediumFactory INSTANCE = new LegacyTmpFileSegmentWriteOutMediumFactory();
+
+  @JsonCreator
+  public static LegacyTmpFileSegmentWriteOutMediumFactory instance()
+  {
+    return INSTANCE;
+  }
+
+  private LegacyTmpFileSegmentWriteOutMediumFactory()
+  {
+  }
+
+  @Override
+  public SegmentWriteOutMedium makeSegmentWriteOutMedium(File outDir) throws IOException
+  {
+    return new LegacyTmpFileSegmentWriteOutMedium(outDir);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumFactory.java
@@ -30,6 +30,7 @@ import java.util.Set;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = TmpFileSegmentWriteOutMediumFactory.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "tmpFile", value = TmpFileSegmentWriteOutMediumFactory.class),
+    @JsonSubTypes.Type(name = "legacyTmpFile", value = LegacyTmpFileSegmentWriteOutMediumFactory.class),
     @JsonSubTypes.Type(name = "offHeapMemory", value = OffHeapMemorySegmentWriteOutMediumFactory.class),
     @JsonSubTypes.Type(name = "onHeapMemory", value = OnHeapMemorySegmentWriteOutMediumFactory.class),
 })
@@ -39,6 +40,7 @@ public interface SegmentWriteOutMediumFactory
   {
     return ImmutableSet.of(
         TmpFileSegmentWriteOutMediumFactory.instance(),
+        LegacyTmpFileSegmentWriteOutMediumFactory.instance(),
         OffHeapMemorySegmentWriteOutMediumFactory.instance(),
         OnHeapMemorySegmentWriteOutMediumFactory.instance()
     );

--- a/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMedium.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/TmpFileSegmentWriteOutMedium.java
@@ -122,15 +122,15 @@ public final class TmpFileSegmentWriteOutMedium implements SegmentWriteOutMedium
   @Override
   public void close() throws IOException
   {
-    log.info("Closing, files still open[%,d], filesBeingClosed[%,d], dir[%s]", filesCreated.get(), numLocallyCreated, dir);
+    log.debug("Closing, files still open[%,d], filesBeingClosed[%,d], dir[%s]", filesCreated.get(), numLocallyCreated, dir);
     filesCreated.set(filesCreated.get() - numLocallyCreated);
     numLocallyCreated = 0;
     closer.close();
 
-    if (root) {
-      log.info("Size distribution of files:");
+    if (root && log.isDebugEnabled()) {
+      log.debug("Size distribution of files:");
       for (Map.Entry<Long, Integer> entry : sizeDistribution.entrySet()) {
-        log.info("%,15d => %,15d", entry.getKey(), entry.getValue());
+        log.debug("%,15d => %,15d", entry.getKey(), entry.getValue());
       }
     }
   }

--- a/processing/src/test/java/org/apache/druid/segment/writeout/LegacyFileWriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/LegacyFileWriteOutBytesTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.writeout;
+
+import org.apache.druid.java.util.common.IAE;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+public class LegacyFileWriteOutBytesTest
+{
+  private LegacyFileWriteOutBytes fileWriteOutBytes;
+  private FileChannel mockFileChannel;
+  private File mockFile;
+
+  @Before
+  public void setUp()
+  {
+    mockFileChannel = EasyMock.mock(FileChannel.class);
+    mockFile = EasyMock.mock(File.class);
+    fileWriteOutBytes = new LegacyFileWriteOutBytes(mockFile, mockFileChannel);
+  }
+
+  @Test
+  public void write4KiBIntsShouldNotFlush() throws IOException
+  {
+    // Write 4KiB of ints and expect the write operation of the file channel will be triggered only once.
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              int remaining = buffer.remaining();
+              buffer.position(remaining);
+              return remaining;
+            }).times(1);
+    EasyMock.replay(mockFileChannel);
+    final int writeBytes = 4096;
+    final int numOfInt = writeBytes / Integer.BYTES;
+    for (int i = 0; i < numOfInt; i++) {
+      fileWriteOutBytes.writeInt(i);
+    }
+    // no need to flush up to 4KiB
+    // the first byte after 4KiB will cause a flush
+    fileWriteOutBytes.write(1);
+    EasyMock.verify(mockFileChannel);
+  }
+
+  @Test
+  public void writeShouldIncrementSize() throws IOException
+  {
+    fileWriteOutBytes.write(1);
+    Assert.assertEquals(1, fileWriteOutBytes.size());
+  }
+
+  @Test
+  public void writeIntShouldIncrementSize() throws IOException
+  {
+    fileWriteOutBytes.writeInt(1);
+    Assert.assertEquals(4, fileWriteOutBytes.size());
+  }
+
+  @Test
+  public void writeBufferLargerThanCapacityShouldIncrementSizeCorrectly() throws IOException
+  {
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              int remaining = buffer.remaining();
+              buffer.position(remaining);
+              return remaining;
+            }).times(1);
+    EasyMock.replay(mockFileChannel);
+    ByteBuffer src = ByteBuffer.allocate(4096 + 1);
+    fileWriteOutBytes.write(src);
+    Assert.assertEquals(src.capacity(), fileWriteOutBytes.size());
+    EasyMock.verify(mockFileChannel);
+  }
+
+  @Test
+  public void writeBufferLargerThanCapacityThrowsIOEInTheMiddleShouldIncrementSizeCorrectly() throws IOException
+  {
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              int remaining = buffer.remaining();
+              buffer.position(remaining);
+              return remaining;
+            }).once();
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andThrow(new IOException())
+            .once();
+    EasyMock.replay(mockFileChannel);
+    ByteBuffer src = ByteBuffer.allocate(4096 * 2 + 1);
+    try {
+      fileWriteOutBytes.write(src);
+      Assert.fail("IOException should have been thrown.");
+    }
+    catch (IOException e) {
+      // The second invocation to flush bytes fails. So the size should count what has already been put successfully
+      Assert.assertEquals(4096 * 2, fileWriteOutBytes.size());
+    }
+  }
+
+  @Test
+  public void writeBufferSmallerThanCapacityShouldIncrementSizeCorrectly() throws IOException
+  {
+    ByteBuffer src = ByteBuffer.allocate(4096);
+    fileWriteOutBytes.write(src);
+    Assert.assertEquals(src.capacity(), fileWriteOutBytes.size());
+  }
+  @Test
+  public void sizeDoesNotFlush() throws IOException
+  {
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andThrow(new AssertionError("file channel should not have been written to."));
+    EasyMock.replay(mockFileChannel);
+    long size = fileWriteOutBytes.size();
+    Assert.assertEquals(0, size);
+    fileWriteOutBytes.writeInt(10);
+    size = fileWriteOutBytes.size();
+    Assert.assertEquals(4, size);
+  }
+
+  @Test
+  public void testReadFullyWorks() throws IOException
+  {
+    int fileSize = 4096;
+    int numOfInt = fileSize / Integer.BYTES;
+    ByteBuffer destination = ByteBuffer.allocate(Integer.BYTES);
+    ByteBuffer underlying = ByteBuffer.allocate(fileSize);
+    // Write 4KiB of ints and expect the write operation of the file channel will be triggered only once.
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              underlying.position(0);
+              underlying.put(buffer);
+              return 0;
+            }).times(1);
+    EasyMock.expect(mockFileChannel.read(EasyMock.eq(destination), EasyMock.eq(100L * Integer.BYTES)))
+            .andAnswer(() -> {
+              ByteBuffer buffer = (ByteBuffer) EasyMock.getCurrentArguments()[0];
+              long pos = (long) EasyMock.getCurrentArguments()[1];
+              buffer.putInt(underlying.getInt((int) pos));
+              return Integer.BYTES;
+            }).times(1);
+    EasyMock.replay(mockFileChannel);
+    for (int i = 0; i < numOfInt; i++) {
+      fileWriteOutBytes.writeInt(i);
+    }
+    Assert.assertEquals(underlying.capacity(), fileWriteOutBytes.size());
+
+    destination.position(0);
+    fileWriteOutBytes.readFully(100L * Integer.BYTES, destination);
+    destination.position(0);
+    Assert.assertEquals(100, destination.getInt());
+    EasyMock.verify(mockFileChannel);
+  }
+
+  @Test
+  public void testReadFullyOutOfBoundsDoesnt() throws IOException
+  {
+    int fileSize = 4096;
+    int numOfInt = fileSize / Integer.BYTES;
+    ByteBuffer destination = ByteBuffer.allocate(Integer.BYTES);
+    EasyMock.replay(mockFileChannel);
+    for (int i = 0; i < numOfInt; i++) {
+      fileWriteOutBytes.writeInt(i);
+    }
+    Assert.assertEquals(fileSize, fileWriteOutBytes.size());
+
+    destination.position(0);
+    Assert.assertThrows(IAE.class, () -> fileWriteOutBytes.readFully(5000, destination));
+    EasyMock.verify(mockFileChannel);
+  }
+
+  @Test
+  public void testIOExceptionHasFileInfo() throws Exception
+  {
+    IOException cause = new IOException("Too many bytes");
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class))).andThrow(cause);
+    EasyMock.expect(mockFile.getAbsolutePath()).andReturn("/tmp/file");
+    EasyMock.replay(mockFileChannel, mockFile);
+    fileWriteOutBytes.writeInt(10);
+    fileWriteOutBytes.write(new byte[30]);
+    IOException actual = Assert.assertThrows(IOException.class, () -> fileWriteOutBytes.flush());
+    Assert.assertEquals(String.valueOf(actual.getCause()), actual.getCause(), cause);
+    Assert.assertEquals(actual.getMessage(), actual.getMessage(), "Failed to write to file: /tmp/file. Current size of file: 34");
+  }
+}


### PR DESCRIPTION
Reintroduce old TmpFileSegmentWriteOutMedium

We make it a legacy option and give it a new name.  It exists solely to give us something to roll back to in case the new logic causes problems that didn't previously exist.  We should update the release notes to also indicate that this is being done and tell people to set the properties for the legacyTmpFile in case they have something that with memory usage and SegmentWriteOutMedium that breaks when upgrading.